### PR TITLE
Add support for GS v1.08 and above and parse build timestamp

### DIFF
--- a/Binary/GameDecoder.cs
+++ b/Binary/GameDecoder.cs
@@ -64,11 +64,13 @@ namespace BacteriaMage.N64.GameShark
 
         private string ReadName()
         {
-            string name = Reader.ReadCString(31);
+            Console.WriteLine($"position = {Reader.Position} (0x{Reader.Position:X8}), bytesRead = {Reader.BytesRead}, length = {Reader.Length}");
 
-            if (name.Length < 1 || name.Length > 30)
+            string name = Reader.ReadCString(30);
+
+            if (name.Length is < 1 or > 30)
             {
-                throw new Exception("Invalid game or cheat name");
+                throw new Exception($"Invalid game or cheat name: '{name}'. Names be printable ASCII between 1-30 characters long, but found length = {name.Length}.");
             }
 
             name = name.Replace("`F6`", "Key");

--- a/Binary/GameDecoder.cs
+++ b/Binary/GameDecoder.cs
@@ -64,8 +64,6 @@ namespace BacteriaMage.N64.GameShark
 
         private string ReadName()
         {
-            Console.WriteLine($"position = {Reader.Position} (0x{Reader.Position:X8}), bytesRead = {Reader.BytesRead}, length = {Reader.Length}");
-
             string name = Reader.ReadCString(30);
 
             if (name.Length is < 1 or > 30)

--- a/Binary/NoteReader.cs
+++ b/Binary/NoteReader.cs
@@ -30,7 +30,7 @@ namespace BacteriaMage.N64.GameShark
 
         private void SkipMpkHeader()
         {
-            if (Reader.ReadUByte() != 0x01 || string.Compare(Reader.ReadCString(), "MPKNote") != 0)
+            if (Reader.ReadUByte() != 0x01 || string.Compare(Reader.ReadCString(), "MPKNote", StringComparison.InvariantCulture) != 0)
             {
                 throw new Exception("Not an MPK Note");
             }

--- a/Binary/NoteWriter.cs
+++ b/Binary/NoteWriter.cs
@@ -17,7 +17,7 @@ namespace BacteriaMage.N64.GameShark
         {
             NoteWriter writer = new NoteWriter();
             writer.WriteGameNote(game);
-            File.WriteAllBytes(path, writer.Writer.Buffer);
+            File.WriteAllBytes(path, writer.Writer.Buffer ?? Array.Empty<byte>());
         }
 
         public NoteWriter()

--- a/Binary/RomReader.cs
+++ b/Binary/RomReader.cs
@@ -1,6 +1,7 @@
 ﻿// bacteriamage.wordpress.com
 
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace BacteriaMage.N64.GameShark
 {
@@ -13,11 +14,17 @@ namespace BacteriaMage.N64.GameShark
         {
             RomReader reader = new RomReader();
             reader.ReadRomFromFile(path);
+            reader.PrintFirmwareVersion();
             return reader.ReadGames();
         }
 
         private RomReader()
         {
+        }
+
+        private void PrintFirmwareVersion()
+        {
+            Console.WriteLine($"GS ROM version: {FirmwareVersion}");
         }
 
         private List<Game> ReadGames()

--- a/Binary/RomWriter.cs
+++ b/Binary/RomWriter.cs
@@ -59,7 +59,7 @@ namespace BacteriaMage.N64.GameShark
 
         private void ClearUnusedPages()
         {
-            while (Writer.Position < Writer.Buffer.Length)
+            while (Writer.Position < Writer.Buffer?.Length)
             {
                 Writer.WriteByte(0xff);
             }

--- a/Binary/Shared/BinaryReader.cs
+++ b/Binary/Shared/BinaryReader.cs
@@ -11,11 +11,11 @@ namespace BacteriaMage.N64.GameShark
     /// </summary>
     class BinaryReader
     {
-        public byte[] Buffer { get; set; }
+        public byte[]? Buffer { get; set; }
         public int Position { get; set; }
         public int BytesRead { get; set; }
 
-        public int Length => Buffer.Length;
+        public int Length => Buffer?.Length ?? 0;
         public bool EndReached => Position >= Length;
 
         public BinaryReader(byte[] buffer)
@@ -39,15 +39,15 @@ namespace BacteriaMage.N64.GameShark
             return this;
         }
 
-        public int ReadUByte()
+        public byte ReadUByte()
         {
             if (Buffer == null || Position == Buffer.Length)
             {
-                throw new IndexOutOfRangeException("End of buffer reached");
+                throw new IndexOutOfRangeException($"End of buffer reached: {Buffer?.Length} (0x{Buffer?.Length:X8})");
             }
             if (Position < 0 || Position > Buffer.Length)
             {
-                throw new IndexOutOfRangeException("Invalid position");
+                throw new IndexOutOfRangeException($"Invalid position: {Position} (0x{Position:X8}). Must be between 0 and {Buffer.Length} (0x{Buffer.Length:X8}).");
             }
 
             byte b = Buffer[Position++];
@@ -57,40 +57,38 @@ namespace BacteriaMage.N64.GameShark
             return b;
         }
 
-        public int ReadSByte()
+        public sbyte ReadSByte()
         {
             return (sbyte)ReadUByte();
         }
 
-        public int ReadUInt16()
+        public UInt16 ReadUInt16()
         {
-            return (ReadUByte() << 8) + ReadUByte();
+            byte b1 = ReadUByte();
+            byte b2 = ReadUByte();
+            int value = (b1 << 8) + b2;
+            return (UInt16) value;
         }
 
-        public int ReadSInt16()
+        public Int16 ReadSInt16()
         {
             return (short)ReadUInt16();
         }
 
-        public uint ReadUInt32()
+        public UInt32 ReadUInt32()
         {
-            uint high = (uint)ReadUInt16();
-            uint low = (uint)ReadUInt16();
+            uint high = ReadUInt16();
+            uint low = ReadUInt16();
 
             return (high << 16) + low;
         }
 
-        public int ReadSInt32()
+        public Int32 ReadSInt32()
         {
             return (int)ReadUInt32();
         }
 
-        public string ReadCString()
-        {
-            return ReadCString(0);
-        }
-
-        public string ReadCString(int max)
+        public string ReadCString(int max = 0)
         {
             StringBuilder builder = new StringBuilder();
 
@@ -130,7 +128,7 @@ namespace BacteriaMage.N64.GameShark
 
         private bool NextByte(out byte b)
         {
-            b = (byte)ReadUByte();
+            b = ReadUByte();
             return b != 0;
         }
     }

--- a/Binary/Shared/BinaryReader.cs
+++ b/Binary/Shared/BinaryReader.cs
@@ -114,6 +114,32 @@ namespace BacteriaMage.N64.GameShark
             }
         }
 
+        public string ReadPrintableCString(int max = 0)
+        {
+            StringBuilder builder = new StringBuilder();
+
+            while (NextPrintableCharacter(out string character) && (max < 1 || builder.Length < max))
+            {
+                builder.Append(character);
+            }
+
+            return builder.ToString();
+        }
+
+        private bool NextPrintableCharacter(out string character)
+        {
+            if (NextByte(out byte b) && b >= ' ' && b <= '~')
+            {
+                character = ByteToCharacter(b);
+                return true;
+            }
+            else
+            {
+                character = "";
+                return false;
+            }
+        }
+
         private string ByteToCharacter(byte b)
         {
             if (b > 127)

--- a/Binary/Shared/BinaryWriter.cs
+++ b/Binary/Shared/BinaryWriter.cs
@@ -13,7 +13,7 @@ namespace BacteriaMage.N64.GameShark
     /// </summary>
     class BinaryWriter
     {
-        public byte[] Buffer { get; set; }
+        public byte[]? Buffer { get; set; }
         public int Position { get; set; }
         public int BytesWritten { get; set; }
         public int AutoExtendSize { get; set; }
@@ -35,7 +35,7 @@ namespace BacteriaMage.N64.GameShark
 
         public void WriteToFile(string path)
         {
-            File.WriteAllBytes(path, Buffer);
+            File.WriteAllBytes(path, Buffer ?? Array.Empty<byte>());
         }
 
         public void Seek(int position)
@@ -45,7 +45,7 @@ namespace BacteriaMage.N64.GameShark
 
         public void SeekEnd()
         {
-            Seek(Buffer.Length);
+            Seek(Buffer?.Length ?? 0);
         }
 
         public void SeekOffset(int offset)
@@ -66,12 +66,12 @@ namespace BacteriaMage.N64.GameShark
             {
                 AutoExtend();
             }
-            if (Position < 0 || Position > Buffer.Length)
+            if (Position < 0 || Position > Buffer?.Length)
             {
                 throw new IndexOutOfRangeException("Invalid position");
             }
 
-            Buffer[Position++] = (byte)b;
+            Buffer![Position++] = (byte)b;
 
             BytesWritten++;
         }
@@ -158,7 +158,7 @@ namespace BacteriaMage.N64.GameShark
 
         private bool ReadEncodedByteAt(string s, ref int p, out byte b)
         {
-            int length = s?.Length ?? 0;
+            int length = s.Length;
 
             if (length - p >= 4)
             {

--- a/Binary/Shared/RomBase.cs
+++ b/Binary/Shared/RomBase.cs
@@ -10,27 +10,27 @@ namespace BacteriaMage.N64.GameShark
         protected BinaryReader Reader { get; private set; }
         protected BinaryWriter Writer { get; private set; }
 
-        protected RomBase()
+        protected RomBase() : this(new BinaryReader())
         {
         }
 
         protected RomBase(BinaryReader reader)
         {
             Reader = reader;
-            Writer = new BinaryWriter(reader.Buffer);
+            Writer = new BinaryWriter(reader.Buffer ?? Array.Empty<byte>());
         }
 
         protected void ReadRomFromFile(string path)
         {
             BinaryReader rom = BinaryReader.FromFile(path);
+            Reader = rom;
 
             if (!ValidateRom(rom))
             {
                 throw new Exception("Not a valid N64 GameShark Pro ROM");
             }
 
-            Reader = rom;
-            Writer = new BinaryWriter(rom.Buffer);
+            Writer = new BinaryWriter(rom.Buffer ?? Array.Empty<byte>());
         }
 
         private bool ValidateRom(BinaryReader rom)

--- a/DataModel/Cheat.cs
+++ b/DataModel/Cheat.cs
@@ -45,12 +45,12 @@ namespace BacteriaMage.N64.GameShark
             return code;
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return Equals(obj as Cheat);
         }
 
-        public bool Equals(Cheat cheat)
+        public bool Equals(Cheat? cheat)
         {
             return string.Equals(Name, cheat?.Name);
         }

--- a/DataModel/Code.cs
+++ b/DataModel/Code.cs
@@ -23,12 +23,12 @@ namespace BacteriaMage.N64.GameShark
             Value = 0x0000;
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return Equals(obj as Code);
         }
 
-        public bool Equals(Code code)
+        public bool Equals(Code? code)
         {
             return (code != null) && (Address == code.Address) && (Value == code.Value);
         }

--- a/DataModel/Game.cs
+++ b/DataModel/Game.cs
@@ -47,12 +47,12 @@ namespace BacteriaMage.N64.GameShark
             return cheat;
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return Equals(obj as Game);
         }
 
-        public bool Equals(Game game)
+        public bool Equals(Game? game)
         {
             return string.Equals(Name, game?.Name);
         }

--- a/DataModel/RomVersion.cs
+++ b/DataModel/RomVersion.cs
@@ -1,0 +1,126 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace BacteriaMage.N64.GameShark;
+
+public class RomVersion
+{
+    public readonly string Raw;
+    public readonly double Number;
+    public readonly DateTime BuildTimestamp;
+
+    private readonly string? _nameClarifier;
+
+    public string DisplayName => ToString();
+
+    // v1.08: "11:58 Nov 24 97" -> 19971124
+    // v1.09: "17:40 Jan 5 98"  -> 19980105
+    // v2.00: "08:06 Mar 5 98"  -> 19980305
+    // v2.00: "10:05 Apr 6 98"  -> 19980406
+    // v2.10: "13:57 Aug 25 98" -> 19980825
+    // v2.21: "12:47 Dec 18 98" -> 19981218
+    // v3.00: "15:05 Apr 1 99"  -> 19990401
+    // v3.10: "16:50 Jun 9 99"  -> 19990609
+    // v3.20: "18:45 Jun 22 99" -> 19990622
+    // v3.21: "14:26 Jan 4"     -> 20000104
+    // v3.30: "09:54 Mar 27"    -> 20000327
+    // v3.30: "15:56 Apr 4"     -> 20000404
+
+    public RomVersion(string rawStr)
+    {
+        Raw = rawStr;
+        string cleanStr = rawStr.Trim();
+        switch (cleanStr)
+        {
+            case "11:58 Nov 24 97":
+                Number = 1.08;
+                BuildTimestamp = new DateTime(1997, 11, 24);
+                break;
+            case "17:40 Jan 5 98":
+                Number = 1.09;
+                BuildTimestamp = new DateTime(1998, 01, 05);
+                break;
+            case "08:06 Mar 5 98":
+                Number = 2.00;
+                BuildTimestamp = new DateTime(1998, 03, 05);
+                _nameClarifier = "March";
+                break;
+            case "10:05 Apr 6 98":
+                Number = 2.00;
+                BuildTimestamp = new DateTime(1998, 04, 06);
+                _nameClarifier = "April";
+                break;
+            case "13:57 Aug 25 98":
+                Number = 2.10;
+                BuildTimestamp = new DateTime(1998, 08, 25);
+                break;
+            // TODO: Find a v2.20 ROM and add its build timestamp here
+            // case "??:?? ??? ?? 98":
+            //     Number = 2.20;
+            //     BuildTimestamp = new DateTime(1998, ??, ??);
+            //     break;
+            case "12:47 Dec 18 98":
+                Number = 2.21;
+                BuildTimestamp = new DateTime(1998, 12, 18);
+                break;
+            case "15:05 Apr 1 99":
+                Number = 3.00;
+                BuildTimestamp = new DateTime(1999, 04, 01);
+                break;
+            case "16:50 Jun 9 99":
+                Number = 3.10;
+                BuildTimestamp = new DateTime(1999, 06, 09);
+                break;
+            case "18:45 Jun 22 99":
+                Number = 3.20;
+                BuildTimestamp = new DateTime(1999, 06, 22);
+                break;
+            case "14:26 Jan 4":
+                Number = 3.21;
+                BuildTimestamp = new DateTime(2000, 01, 04);
+                break;
+            case "09:54 Mar 27":
+                Number = 3.30;
+                BuildTimestamp = new DateTime(2000, 03, 27);
+                _nameClarifier = "March";
+                break;
+            case "15:56 Apr 4":
+                Number = 3.30;
+                BuildTimestamp = new DateTime(2000, 04, 04);
+                _nameClarifier = "April";
+                break;
+            default:
+                var match = Regex.Match(cleanStr, @"(?<HH>\d\d):(?<mm>\d\d) (?<MMM>\w\w\w) (?<dd>\d\d?)(?: (?<yy>\d\d)?)?");
+                if (!match.Success)
+                {
+                    Console.Error.WriteLine($"ERROR: Invalid GS ROM build timestamp: '{cleanStr}'(len = {cleanStr.Length}). Expected HH:mm MMM dd [yy].");
+                    break;
+                }
+                var HH = match.Groups["HH"].Value;
+                var mm = match.Groups["mm"].Value;
+                var MMM = match.Groups["MMM"].Value;
+                var dd = match.Groups["dd"].Value;
+                // v3.21 and v3.0 builds omit the year from the timestamp.
+                var yy = match.Groups["yy"].Success ? match.Groups["yy"].Value : "97";
+                cleanStr = $"{HH}:{mm} {MMM} {dd} 19{yy}";
+                if (!Is(cleanStr, "HH:mm MMM d yyyy", out BuildTimestamp))
+                {
+                    Console.Error.WriteLine($"ERROR: Invalid GS ROM build timestamp: '{cleanStr}' (len = {cleanStr.Length}). Expected HH:mm MMM dd yyyy.");
+                    break;
+                }
+                break;
+        }
+    }
+
+    private static bool Is(string rawDateTime, string dateTimeFormat, out DateTime datetime)
+    {
+        return DateTime.TryParseExact(rawDateTime, dateTimeFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out datetime);
+    }
+
+    public override string ToString()
+    {
+        return $"v{Number:F2}" +
+               (string.IsNullOrEmpty(_nameClarifier) ? "" : $" ({_nameClarifier}),") +
+               $" built on {BuildTimestamp:yyyy-MM-dd}";
+    }
+}

--- a/Examples.cs
+++ b/Examples.cs
@@ -52,7 +52,7 @@ namespace BacteriaMage.N64.GameShark
         /// </summary>
         /// <param name="inputNotePath">Path to the note's MPK file</param>
         /// <param name="writer">Writer to write to; defaults to stdout if not specified</param>
-        public static void DisplayNote(string inputNotePath, TextWriter writer = null)
+        public static void DisplayNote(string inputNotePath, TextWriter? writer = null)
         {
             Game game = NoteReader.FromFile(inputNotePath);
 
@@ -84,7 +84,7 @@ namespace BacteriaMage.N64.GameShark
         }
 
         /// <summary>
-        /// Encrypt a GameShark ROM so that it can be flashed with the offical N64 utility.
+        /// Encrypt a GameShark ROM so that it can be flashed with the official N64 utility.
         /// </summary>
         /// <param name="inputPlainTextRomPath">Path to the input ROM</param>
         /// <param name="outputEncryptedRomPath">Path to the output ROM (e.g. ar3.enc)</param>
@@ -94,7 +94,7 @@ namespace BacteriaMage.N64.GameShark
         }
 
         /// <summary>
-        /// Decrypt a plain-text GameShark ROM from an encoded ROM file used by the official N64 utility.
+        /// Decrypt an encoded ROM file (used by the official N64 utility) to a plain-text GameShark ROM.
         /// </summary>
         /// <param name="inputEncryptedRomPath">Path to the encrypted ROM (e.g. ar3.enc)</param>
         /// <param name="outputPlainTextRomPath">Path to plain-text output ROM file</param>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # N64 GameShark C# Data Model
 
-Just some quick-and-dirty classes representing the Games/Cheats/Codes data model used by the [Nintendo 64 GameShark](https://gameshark.fandom.com/wiki/Nintendo_64) Pro 3.x plus a couple of helper classes for reading and writing this data. The helpers can read and write the binary formats the GameShark itself uses as well the text format used by the [official N64 Utility program](http://web.archive.org/web/20110426190730/http://gscentral.org/tools/n64/gs_pro_utils.zip). I created these classes while playing around with some of the devices in my personal collection.
+Just some quick-and-dirty classes representing the Games/Cheats/Codes data model used by the [Nintendo 64 GameShark](https://gameshark.fandom.com/wiki/Nintendo_64) v1.08 and newer, plus a couple of helper classes for reading and writing this data. The helpers can read and write the binary formats the GameShark itself uses as well the text format used by the [official N64 Utility program](http://web.archive.org/web/20110426190730/http://gscentral.org/tools/n64/gs_pro_utils.zip). I created these classes while playing around with some of the devices in my personal collection.
 
 ## Note Files
 

--- a/Text/ListReader.cs
+++ b/Text/ListReader.cs
@@ -16,8 +16,8 @@ namespace BacteriaMage.N64.GameShark
         private IEnumerable<string> Lines;
 
         private readonly List<Game> Games = new List<Game>();
-        private Game Game;
-        private Cheat Cheat;
+        private Game? Game;
+        private Cheat? Cheat;
         private int LineNumber;
 
         public static List<Game> ReadLines(string path)
@@ -38,6 +38,7 @@ namespace BacteriaMage.N64.GameShark
 
         private ListReader()
         {
+            Lines = new List<string>();
             Game = null;
             Cheat = null;
             LineNumber = 1;


### PR DESCRIPTION
This PR:

1. Parses the build timestamp found in the GS ROM's header (e.g., `"17:40 Jan 5 98"`)
2. Infers the GameShark version number for all known timestamps
    - New/unknown timestamps are also supported, but the GS version number obviously cannot be inferred
3. Adds support for GS v1.08 through v2.21 by looking for the list of games at a different offset than v3.0 and above
4. Adds more detailed error messages and fixes some linter warnings

Example output:

```bash
$ for ROM in gs*.z64; do dotnet run --project ~/dev/rider/gsrom64dotnet/src/src.csproj -- "$ROM"; done
GS ROM version: v1.08 built on 1997-11-24
GS ROM version: v1.09 built on 1998-01-05
GS ROM version: v2.00 (March), built on 1998-03-05
GS ROM version: v2.10 built on 1998-08-25
GS ROM version: v2.21 built on 1998-12-18
GS ROM version: v3.00 built on 1999-04-01
GS ROM version: v3.20 built on 1999-06-22
GS ROM version: v3.30 (April), built on 2000-04-04
```